### PR TITLE
Feat/#42 회원 프로필 이미지 삭제 기능 테스트

### DIFF
--- a/src/main/java/com/dateplan/dateplan/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dateplan/dateplan/domain/member/controller/MemberController.java
@@ -29,8 +29,7 @@ public class MemberController {
 	@GetMapping("/profile/image/presigned-url")
 	public ApiResponse<PresignedURLResponse> getPresignedURL() {
 
-		PresignedURLResponse presingedURL = memberService.getPresignedURL(
-			S3ImageType.MEMBER_PROFILE);
+		PresignedURLResponse presingedURL = memberService.getPresignedURLForProfileImage();
 
 		return ApiResponse.ofSuccess(presingedURL);
 	}
@@ -38,7 +37,7 @@ public class MemberController {
 	@PutMapping("/profile/image")
 	public ApiResponse<Void> modifyProfileImage() {
 
-		memberService.checkAndSaveImage(S3ImageType.MEMBER_PROFILE);
+		memberService.checkAndSaveProfileImage();
 
 		return ApiResponse.ofSuccess();
 	}

--- a/src/main/java/com/dateplan/dateplan/domain/member/service/MemberService.java
+++ b/src/main/java/com/dateplan/dateplan/domain/member/service/MemberService.java
@@ -38,24 +38,24 @@ public class MemberService {
 		authService.deleteAuthenticationInfoInRedis(phone);
 	}
 
-	public PresignedURLResponse getPresignedURL(S3ImageType imageType) {
+	public PresignedURLResponse getPresignedURLForProfileImage() {
 
 		Member member = MemberThreadLocal.get();
 
-		URL preSignedUrl = s3Client.getPreSignedUrl(imageType, member.getId().toString());
+		URL preSignedUrl = s3Client.getPreSignedUrl(S3ImageType.MEMBER_PROFILE, member.getId().toString());
 
 		return PresignedURLResponse.builder()
 			.presignedURL(preSignedUrl.toString())
 			.build();
 	}
 
-	public void checkAndSaveImage(S3ImageType imageType) {
+	public void checkAndSaveProfileImage() {
 
 		Member member = MemberThreadLocal.get();
 		String memberIdStr = member.getId().toString();
 
-		s3Client.throwIfImageNotFound(imageType, memberIdStr);
-		URL url = s3Client.getObjectUrl(imageType, memberIdStr);
+		s3Client.throwIfImageNotFound(S3ImageType.MEMBER_PROFILE, memberIdStr);
+		URL url = s3Client.getObjectUrl(S3ImageType.MEMBER_PROFILE, memberIdStr);
 
 		member.updateProfileImageUrl(url.toString());
 

--- a/src/test/java/com/dateplan/dateplan/controller/member/MemberController/MemberControllerTest.java
+++ b/src/test/java/com/dateplan/dateplan/controller/member/MemberController/MemberControllerTest.java
@@ -4,6 +4,7 @@ import static com.dateplan.dateplan.global.exception.ErrorCode.DetailMessage.ALR
 import static com.dateplan.dateplan.global.exception.ErrorCode.DetailMessage.INVALID_CONNECTION_CODE;
 import static com.dateplan.dateplan.global.exception.ErrorCode.DetailMessage.INVALID_CONNECTION_CODE_PATTERN;
 import static com.dateplan.dateplan.global.exception.ErrorCode.DetailMessage.S3_CREATE_PRESIGNED_URL_FAIL;
+import static com.dateplan.dateplan.global.exception.ErrorCode.DetailMessage.S3_DELETE_OBJECT_FAIL;
 import static com.dateplan.dateplan.global.exception.ErrorCode.DetailMessage.S3_IMAGE_NOT_FOUND;
 import static com.dateplan.dateplan.global.exception.ErrorCode.DetailMessage.SELF_CONNECTION_NOT_ALLOWED;
 import static com.dateplan.dateplan.global.exception.ErrorCode.INVALID_INPUT_VALUE;
@@ -11,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -23,7 +25,6 @@ import com.dateplan.dateplan.domain.member.dto.ConnectionRequest;
 import com.dateplan.dateplan.domain.member.dto.ConnectionServiceRequest;
 import com.dateplan.dateplan.domain.member.dto.ConnectionServiceResponse;
 import com.dateplan.dateplan.domain.member.dto.PresignedURLResponse;
-import com.dateplan.dateplan.domain.s3.S3ImageType;
 import com.dateplan.dateplan.global.exception.ErrorCode;
 import com.dateplan.dateplan.global.exception.S3Exception;
 import com.dateplan.dateplan.global.exception.S3ImageNotFoundException;
@@ -48,7 +49,9 @@ public class MemberControllerTest extends ControllerTestSupport {
 
 	@BeforeEach
 	void setUp() throws Exception {
-		given(authInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any(Object.class)))
+		given(
+			authInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class),
+				any(Object.class)))
 			.willReturn(true);
 	}
 
@@ -303,6 +306,49 @@ public class MemberControllerTest extends ControllerTestSupport {
 					jsonPath("$.success").value("false"),
 					jsonPath("$.code").value(ErrorCode.S3_IMAGE_NOT_FOUND.getCode()),
 					jsonPath("$.message").value(S3_IMAGE_NOT_FOUND)
+				);
+		}
+	}
+
+	@Nested
+	@DisplayName("회원 프로필 이미지 삭제 요청시")
+	class DeleteProfileImage {
+
+		private static final String REQUEST_URL = "/api/members/profile/image";
+
+		@DisplayName("S3 요청, 응답에 문제가 없다면 요청에 성공한다.")
+		@Test
+		void withAvailableS3() throws Exception {
+
+			// Stub
+			willDoNothing()
+				.given(memberService)
+				.deleteProfileImage();
+
+			// When & Then
+			mockMvc.perform(delete(REQUEST_URL))
+				.andExpect(status().isOk());
+		}
+
+		@DisplayName("S3 요청, 응답에 문제가 있다면 에러 코드, 메시지를 응답한다.")
+		@Test
+		void withUnAvailableS3() throws Exception {
+
+			// Stub
+			SdkClientException sdkClientException = new SdkClientException("message");
+			S3Exception expectedException = new S3Exception(S3_DELETE_OBJECT_FAIL,
+				sdkClientException);
+			willThrow(expectedException)
+				.given(memberService)
+				.deleteProfileImage();
+
+			// When & Then
+			mockMvc.perform(delete(REQUEST_URL))
+				.andExpect(status().isServiceUnavailable())
+				.andExpectAll(
+					jsonPath("$.success").value("false"),
+					jsonPath("$.code").value(ErrorCode.S3_ERROR.getCode()),
+					jsonPath("$.message").value(S3_DELETE_OBJECT_FAIL)
 				);
 		}
 	}

--- a/src/test/java/com/dateplan/dateplan/controller/member/MemberController/MemberControllerTest.java
+++ b/src/test/java/com/dateplan/dateplan/controller/member/MemberController/MemberControllerTest.java
@@ -235,7 +235,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 			PresignedURLResponse expectedResponse = createPresignedURLResponse(expectedURLStr);
 
 			// Stub
-			given(memberService.getPresignedURL(any(S3ImageType.class)))
+			given(memberService.getPresignedURLForProfileImage())
 				.willReturn(expectedResponse);
 
 			// When & Then
@@ -252,7 +252,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 			SdkClientException sdkClientException = new SdkClientException("message");
 			S3Exception expectedException = new S3Exception(S3_CREATE_PRESIGNED_URL_FAIL,
 				sdkClientException);
-			given(memberService.getPresignedURL(any(S3ImageType.class)))
+			given(memberService.getPresignedURLForProfileImage())
 				.willThrow(expectedException);
 
 			// When & Then
@@ -279,7 +279,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 			// Stub
 			willDoNothing()
 				.given(memberService)
-				.checkAndSaveImage(any(S3ImageType.class));
+				.checkAndSaveProfileImage();
 
 			// When & Then
 			mockMvc.perform(put(REQUEST_URL))
@@ -294,7 +294,7 @@ public class MemberControllerTest extends ControllerTestSupport {
 			S3ImageNotFoundException expectedException = new S3ImageNotFoundException();
 			willThrow(expectedException)
 				.given(memberService)
-				.checkAndSaveImage(any(S3ImageType.class));
+				.checkAndSaveProfileImage();
 
 			// When & Then
 			mockMvc.perform(put(REQUEST_URL))

--- a/src/test/java/com/dateplan/dateplan/service/member/MemberServiceTest.java
+++ b/src/test/java/com/dateplan/dateplan/service/member/MemberServiceTest.java
@@ -254,7 +254,7 @@ public class MemberServiceTest extends ServiceTestSupport {
 				.willReturn(expectedURL);
 
 			// When
-			PresignedURLResponse response = memberService.getPresignedURL(imageType);
+			PresignedURLResponse response = memberService.getPresignedURLForProfileImage();
 
 			// Then
 			assertThat(response.getPresignedURL()).isEqualTo(expectedURL.toString());
@@ -278,7 +278,7 @@ public class MemberServiceTest extends ServiceTestSupport {
 				.willThrow(expectedException);
 
 			// When & Then
-			assertThatThrownBy(() -> memberService.getPresignedURL(imageType))
+			assertThatThrownBy(() -> memberService.getPresignedURLForProfileImage())
 				.isInstanceOf(S3Exception.class)
 				.hasMessage(S3_CREATE_PRESIGNED_URL_FAIL)
 				.hasCauseInstanceOf(SdkClientException.class);
@@ -289,9 +289,9 @@ public class MemberServiceTest extends ServiceTestSupport {
 		}
 	}
 
-	@DisplayName("이미지 저장 요청시")
+	@DisplayName("회원 프로필 이미지 저장 요청시")
 	@Nested
-	class CheckAndSaveImage {
+	class CheckAndSaveProfileImage {
 
 		private Member savedMember;
 
@@ -312,9 +312,6 @@ public class MemberServiceTest extends ServiceTestSupport {
 		@Test
 		void withExistsImageInS3() throws MalformedURLException {
 
-			// Given
-			S3ImageType imageType = S3ImageType.MEMBER_PROFILE;
-
 			// Stub
 			URL expectedURL = new URL("https://something.com");
 			doNothing()
@@ -324,7 +321,7 @@ public class MemberServiceTest extends ServiceTestSupport {
 				.willReturn(expectedURL);
 
 			// When
-			memberService.checkAndSaveImage(imageType);
+			memberService.checkAndSaveProfileImage();
 
 			// Then
 			then(s3Client)
@@ -345,7 +342,6 @@ public class MemberServiceTest extends ServiceTestSupport {
 		void withNotExistsImageInS3() {
 
 			// Given
-			S3ImageType imageType = S3ImageType.MEMBER_PROFILE;
 			String savedImageURL = savedMember.getProfileImageUrl();
 
 			// Stub
@@ -355,7 +351,7 @@ public class MemberServiceTest extends ServiceTestSupport {
 				.throwIfImageNotFound(any(S3ImageType.class), anyString());
 
 			// When & Then
-			assertThatThrownBy(() -> memberService.checkAndSaveImage(imageType))
+			assertThatThrownBy(() -> memberService.checkAndSaveProfileImage())
 				.isInstanceOf(S3ImageNotFoundException.class)
 				.hasMessage(S3_IMAGE_NOT_FOUND);
 


### PR DESCRIPTION
## 테스트 목록
- S3Client
<img width="641" alt="스크린샷 2023-06-07 19 12 46" src="https://github.com/date-plan/back-end/assets/67905075/f8d40499-973c-4955-97b5-6a4158c0e966">

- MemberController
<img width="800" alt="스크린샷 2023-06-07 19 13 58" src="https://github.com/date-plan/back-end/assets/67905075/f1bdfb48-9b52-4acb-9402-762ce8897ddc">

- MemberService
<img width="807" alt="스크린샷 2023-06-07 19 13 35" src="https://github.com/date-plan/back-end/assets/67905075/ee267328-d725-43db-95d1-431f142f52d6">
